### PR TITLE
[feat]: [CI-12621]: Update drone-buildx version for DLC savings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/coreos/go-semver v0.3.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/drone-plugins/drone-buildx v1.0.2 // indirect
-	github.com/drone-plugins/drone-plugin-lib v0.4.1 // indirect
+	github.com/drone-plugins/drone-buildx v1.1.7 // indirect
+	github.com/drone-plugins/drone-plugin-lib v0.4.2 // indirect
 	github.com/drone/drone-go v1.7.1 // indirect
 	github.com/inhies/go-bytesize v0.0.0-20210819104631-275770b98743 // indirect
 	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,10 +19,14 @@ github.com/drone-plugins/drone-buildx v1.0.2-0.20230512061850-99d0da95877e h1:UV
 github.com/drone-plugins/drone-buildx v1.0.2-0.20230512061850-99d0da95877e/go.mod h1:2CEwXGujWoB9bBQqknU214yd/FJzUNDDHGlg9qb3M4c=
 github.com/drone-plugins/drone-buildx v1.0.2 h1:zlqCAko0frvNO9kXUPnsoyc0BxDoR93s5ieaTDItdDw=
 github.com/drone-plugins/drone-buildx v1.0.2/go.mod h1:z4BaR8J5oF/yly5VPW0PU61XOmrqsZvb5kdarmmSmho=
+github.com/drone-plugins/drone-buildx v1.1.7 h1:v++Lb1xJ5pAyN/Mo+NZFtuDLvyWRdGM+LgzuSsArHqU=
+github.com/drone-plugins/drone-buildx v1.1.7/go.mod h1:vof8lA/q9NCcKPV4HSipz30+Du4o10wIcmp+tOlX4yI=
 github.com/drone-plugins/drone-docker v0.0.0-20230504121258-6cf4d8e9e90e h1:UhvXwQ8PNv+EQL3sLqQmYftl9IKjCuwg/TnXdDkDrAQ=
 github.com/drone-plugins/drone-docker v0.0.0-20230504121258-6cf4d8e9e90e/go.mod h1:wOk9jpb8terZ3igOdTSaW32SCvfXwV9zfRs7YMokYAg=
 github.com/drone-plugins/drone-plugin-lib v0.4.1 h1:47rZlmcMpr1hSp+6Gl+1Z4t+efi/gMQU3lxukC1Yg64=
 github.com/drone-plugins/drone-plugin-lib v0.4.1/go.mod h1:KwCu92jFjHV3xv2hu5Qg/8zBNvGwbhoJDQw/EwnTvoM=
+github.com/drone-plugins/drone-plugin-lib v0.4.2 h1:EiJ3Kco6ypP5noBQqVt1bBbuO1eUAumtPvLTX/NVAYg=
+github.com/drone-plugins/drone-plugin-lib v0.4.2/go.mod h1:KwCu92jFjHV3xv2hu5Qg/8zBNvGwbhoJDQw/EwnTvoM=
 github.com/drone/drone-go v1.7.1 h1:ZX+3Rs8YHUSUQ5mkuMLmm1zr1ttiiE2YGNxF3AnyDKw=
 github.com/drone/drone-go v1.7.1/go.mod h1:fxCf9jAnXDZV1yDr0ckTuWd1intvcQwfJmTRpTZ1mXg=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=


### PR DESCRIPTION
Cache metrics being successfully written, parsed and uploaded to ti-service

FULL RUN 

<img width="1728" alt="Screenshot 2024-06-05 at 10 26 11 AM" src="https://github.com/drone-plugins/drone-buildx-ecr/assets/114451080/b9d8a674-6fe3-4583-a546-27b63d7ad9dc">
<img width="1728" alt="Screenshot 2024-06-05 at 10 26 17 AM" src="https://github.com/drone-plugins/drone-buildx-ecr/assets/114451080/00e28b18-057a-4861-974a-0a88ccced8b4">


OPTIMIZED RUN

<img width="1728" alt="Screenshot 2024-06-05 at 10 27 15 AM" src="https://github.com/drone-plugins/drone-buildx-ecr/assets/114451080/3e6d349e-07d9-40e1-9617-05229c593ab9">
<img width="1728" alt="Screenshot 2024-06-05 at 10 27 26 AM" src="https://github.com/drone-plugins/drone-buildx-ecr/assets/114451080/87b16963-2e09-4c8e-aee9-ff92380ca3e3">


TI Service Savings Table Entries for both runs
<img width="1728" alt="Screenshot 2024-06-05 at 10 28 53 AM" src="https://github.com/drone-plugins/drone-buildx-ecr/assets/114451080/d49837da-8020-40c6-8248-5ef4137139fb">

