### PR TITLE
build and push image tags to plugins/drone-buildx-ecr repository

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -80,7 +80,7 @@ depends_on:
 
 trigger:
   ref:
-    - refs/heads/master
+    - refs/heads/main
     - refs/tags/*
     - "refs/pull/**"
 
@@ -122,7 +122,7 @@ depends_on:
 
 trigger:
   ref:
-    - refs/heads/master
+    - refs/heads/main
     - refs/tags/*
     - "refs/pull/**"
 
@@ -177,7 +177,7 @@ steps:
 
 trigger:
   ref:
-    - refs/heads/master
+    - refs/heads/main
     - "refs/tags/**"
     - "refs/pull/**"
 
@@ -237,7 +237,7 @@ steps:
 
 trigger:
   ref:
-    - refs/heads/master
+    - refs/heads/main
     - "refs/tags/**"
     - "refs/pull/**"
 
@@ -269,7 +269,7 @@ steps:
 
 trigger:
   ref:
-    - refs/heads/master
+    - refs/heads/main
     - "refs/tags/**"
 
 depends_on:

--- a/.drone.yml
+++ b/.drone.yml
@@ -42,6 +42,243 @@ trigger:
     - "refs/pull/**"
 
 ---
+kind: pipeline
+type: vm
+name: windows-1809
+
+pool:
+  use: windows
+
+platform:
+  os: windows
+  arch: amd64
+
+steps:
+  - name: go build
+    image: golang:1.19
+    environment:
+      CGO_ENABLED: 0
+    commands:
+      - go build -o release/windows/amd64/buildx-ecr.exe ./cmd/drone-buildx-ecr
+  - name: build ecr plugin
+    image: plugins/docker:20.17.4-windows-1809-amd64
+    settings:
+      dockerfile: docker/ecr/Dockerfile.windows.amd64.1809
+      repo: plugins/buildx-ecr
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      auto_tag: true
+      auto_tag_suffix: windows-1809-amd64
+      purge: false
+    when:
+      event: [push, tag]
+
+depends_on:
+  - testing
+
+trigger:
+  ref:
+    - refs/heads/master
+    - refs/tags/*
+    - "refs/pull/**"
+
+---
+kind: pipeline
+type: vm
+name: windows-ltsc2022
+
+pool:
+  use: windows-2022
+
+platform:
+  os: windows
+
+steps:
+  - name: go build
+    image: golang:1.19
+    environment:
+      CGO_ENABLED: 0
+    commands:
+      - go build -o release/windows/amd64/buildx-ecr.exe ./cmd/drone-buildx-ecr
+  - name: build ecr plugin
+    image: plugins/docker
+    settings:
+      dockerfile: docker/ecr/Dockerfile.windows.amd64.ltsc2022
+      repo: plugins/buildx-ecr
+      username:
+        from_secret: docker_username
+      password:
+        from_secret: docker_password
+      auto_tag: true
+      auto_tag_suffix: windows-ltsc2022-amd64
+      purge: false
+    when:
+      event: [push, tag]
+
+depends_on:
+  - testing
+
+trigger:
+  ref:
+    - refs/heads/master
+    - refs/tags/*
+    - "refs/pull/**"
+
+---
+kind: pipeline
+name: linux-amd64-ecr
+type: vm
+
+pool:
+  use: ubuntu
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+  - name: build-push
+    image: golang:1.19
+    commands:
+      - 'go build -v -ldflags "-X main.build=${DRONE_BUILD_NUMBER}" -a -tags netgo -o release/linux/amd64/buildx-ecr ./cmd/drone-buildx-ecr'
+    environment:
+      CGO_ENABLED: 0
+    when:
+      event:
+        exclude:
+          - tag
+  - name: build-tag
+    image: golang:1.19
+    commands:
+      - 'go build -v -ldflags "-X main.version=${DRONE_TAG##v} -X main.build=${DRONE_BUILD_NUMBER}" -a -tags netgo -o release/linux/amd64/buildx-ecr ./cmd/drone-buildx-ecr'
+    environment:
+      CGO_ENABLED: 0
+    when:
+      event:
+        - tag
+  - name: publish
+    image: plugins/docker:18
+    settings:
+      auto_tag: true
+      auto_tag_suffix: linux-amd64
+      daemon_off: false
+      dockerfile: docker/ecr/Dockerfile.linux.amd64
+      password:
+        from_secret: docker_password
+      repo: plugins/buildx-ecr
+      username:
+        from_secret: docker_username
+    when:
+      event:
+        exclude:
+          - pull_request
+
+trigger:
+  ref:
+    - refs/heads/master
+    - "refs/tags/**"
+    - "refs/pull/**"
+
+depends_on:
+  - testing
+
+---
+kind: pipeline
+name: linux-arm64-ecr
+type: vm
+
+pool:
+  use: ubuntu_arm64
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+  - name: build-push
+    image: golang:1.19
+    commands:
+      - 'go build -v -ldflags "-X main.build=${DRONE_BUILD_NUMBER}" -a -tags netgo -o release/linux/arm64/buildx-ecr ./cmd/drone-buildx-ecr'
+    environment:
+      CGO_ENABLED: 0
+    when:
+      event:
+        exclude:
+          - tag
+
+  - name: build-tag
+    image: golang:1.19
+    commands:
+      - 'go build -v -ldflags "-X main.version=${DRONE_TAG##v} -X main.build=${DRONE_BUILD_NUMBER}" -a -tags netgo -o release/linux/arm64/buildx-ecr ./cmd/drone-buildx-ecr'
+    environment:
+      CGO_ENABLED: 0
+    when:
+      event:
+        - tag
+
+  - name: publish
+    image: plugins/docker:18
+    settings:
+      auto_tag: true
+      auto_tag_suffix: linux-arm64
+      daemon_off: false
+      dockerfile: docker/ecr/Dockerfile.linux.arm64
+      password:
+        from_secret: docker_password
+      repo: plugins/buildx-ecr
+      username:
+        from_secret: docker_username
+    when:
+      event:
+        exclude:
+          - pull_request
+
+trigger:
+  ref:
+    - refs/heads/master
+    - "refs/tags/**"
+    - "refs/pull/**"
+
+depends_on:
+  - testing
+
+---
+kind: pipeline
+name: notifications-ecr
+type: vm
+
+pool:
+  use: ubuntu
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+  - name: manifest
+    image: plugins/manifest
+    settings:
+      ignore_missing: true
+      password:
+        from_secret: docker_password
+      spec: docker/ecr/manifest.tmpl
+      username:
+        from_secret: docker_username
+
+trigger:
+  ref:
+    - refs/heads/master
+    - "refs/tags/**"
+
+depends_on:
+  - windows-1809
+  - windows-ltsc2022
+  - linux-amd64-ecr
+  - linux-arm64-ecr
+
+---
 
 kind: pipeline
 name: release-binaries

--- a/docker/ecr/Dockerfile.linux.amd64
+++ b/docker/ecr/Dockerfile.linux.amd64
@@ -1,0 +1,4 @@
+FROM plugins/buildx:linux-amd64
+
+ADD release/linux/amd64/buildx-ecr /bin/
+ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh", "/bin/buildx-ecr"]

--- a/docker/ecr/Dockerfile.linux.arm64
+++ b/docker/ecr/Dockerfile.linux.arm64
@@ -1,0 +1,4 @@
+FROM plugins/buildx:linux-arm64
+
+ADD release/linux/arm64/buildx-ecr /bin/
+ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh", "/bin/buildx-ecr"]

--- a/docker/ecr/Dockerfile.windows.amd64.1809
+++ b/docker/ecr/Dockerfile.windows.amd64.1809
@@ -1,0 +1,10 @@
+# escape=`
+FROM plugins/buildx:windows-1809-amd64
+
+LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `
+  org.label-schema.name="Drone ECR" `
+  org.label-schema.vendor="Drone.IO Community" `
+  org.label-schema.schema-version="1.0"
+
+ADD release/windows/amd64/buildx-ecr.exe C:/bin/buildx-ecr.exe
+ENTRYPOINT [ "C:\\bin\\buildx-ecr.exe" ]

--- a/docker/ecr/Dockerfile.windows.amd64.ltsc2022
+++ b/docker/ecr/Dockerfile.windows.amd64.ltsc2022
@@ -1,0 +1,10 @@
+# escape=`
+FROM plugins/buildx:windows-ltsc2022-amd64
+
+LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `
+  org.label-schema.name="Drone ECR" `
+  org.label-schema.vendor="Drone.IO Community" `
+  org.label-schema.schema-version="1.0"
+
+ADD release/windows/amd64/buildx-ecr.exe C:/bin/buildx-ecr.exe
+ENTRYPOINT [ "C:\\bin\\buildx-ecr.exe" ]

--- a/docker/ecr/manifest.tmpl
+++ b/docker/ecr/manifest.tmpl
@@ -1,0 +1,31 @@
+image: plugins/buildx-ecr:{{#if build.tag}}{{trimPrefix "v" build.tag}}{{else}}latest{{/if}}
+{{#if build.tags}}
+tags:
+{{#each build.tags}}
+  - {{this}}
+{{/each}}
+{{/if}}
+manifests:
+  -
+    image: plugins/buildx-ecr:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64
+    platform:
+      architecture: amd64
+      os: linux
+  -
+    image: plugins/buildx-ecr:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-arm64
+    platform:
+      architecture: arm64
+      os: linux
+      variant: v8
+  -
+    image: plugins/buildx-ecr:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}windows-1809-amd64
+    platform:
+      architecture: amd64
+      os: windows
+      version: 1809
+  -
+    image: plugins/buildx-ecr:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}windows-ltsc2022-amd64
+    platform:
+      architecture: amd64
+      os: windows
+      version: ltsc2022


### PR DESCRIPTION
Adding the support to build and push docker image for the respective plugins in its own repo, all of which was originally handled in drone-buildx plugin.  
Creating and uploading the binary executables for all linux-amd, linux-arm, windows.