### PR TITLE
fix: [CI-21699]: resolve EoL components and security advisories

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.24.11
+go 1.25.0
 
-toolchain go1.25.5
+toolchain go1.25.8

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.10
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.55.3
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.7
-	github.com/drone-plugins/drone-buildx v1.3.16
+	github.com/drone-plugins/drone-buildx v1.3.17
 	github.com/joho/godotenv v1.3.0
 )
 
@@ -33,6 +33,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.25.0
-
-toolchain go1.25.8
+go 1.26

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/drone-plugins/drone-buildx v1.3.15 h1:yC7TPybKsOmkTKZGpnRKoD8x5WGNSoZuIZvf5R+76L4=
-github.com/drone-plugins/drone-buildx v1.3.15/go.mod h1:6eZFsU2bAsY1GAmpw4vQODk/6VIyC+UdbArbALPUHJw=
 github.com/drone-plugins/drone-buildx v1.3.16 h1:SwTLl5s86arm27RIJXYGwV+eFhGzgnE/vveuTdP/6sQ=
 github.com/drone-plugins/drone-buildx v1.3.16/go.mod h1:6eZFsU2bAsY1GAmpw4vQODk/6VIyC+UdbArbALPUHJw=
 github.com/drone-plugins/drone-plugin-lib v0.4.2 h1:EiJ3Kco6ypP5noBQqVt1bBbuO1eUAumtPvLTX/NVAYg=

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/drone-plugins/drone-buildx v1.3.16 h1:SwTLl5s86arm27RIJXYGwV+eFhGzgnE/vveuTdP/6sQ=
-github.com/drone-plugins/drone-buildx v1.3.16/go.mod h1:6eZFsU2bAsY1GAmpw4vQODk/6VIyC+UdbArbALPUHJw=
+github.com/drone-plugins/drone-buildx v1.3.17 h1:KXWovDJ59ZaeHyZ3mrqSxM3wQ5X5ltSJTMGQ7Gaeej8=
+github.com/drone-plugins/drone-buildx v1.3.17/go.mod h1:MbPN45ES9bvQIO8NP7liagrZy5y+Oz0GLNgp6Se6Kf8=
 github.com/drone-plugins/drone-plugin-lib v0.4.2 h1:EiJ3Kco6ypP5noBQqVt1bBbuO1eUAumtPvLTX/NVAYg=
 github.com/drone-plugins/drone-plugin-lib v0.4.2/go.mod h1:KwCu92jFjHV3xv2hu5Qg/8zBNvGwbhoJDQw/EwnTvoM=
 github.com/drone/drone-go v1.7.1 h1:ZX+3Rs8YHUSUQ5mkuMLmm1zr1ttiiE2YGNxF3AnyDKw=


### PR DESCRIPTION
Address End-of-Life (EoL) components and security vulnerabilities identified in CI-21699 for plugins/buildx-ecr Docker images.

## Go Version Upgrade
- Upgrade Go from 1.21.0 to 1.25.0 (go1.21.x EOL: 2024-08-13)
- Add toolchain go1.25.8 (go1.24.x EOL: 2026-02-11)

## Base Image
- Uses plugins/buildx as base (updated separately in CI-21697)
- Inherits Docker 29.3.1-dind, buildx v0.32.1, and security fixes

## Go Dependencies Updated
- github.com/aws/aws-sdk-go: v1.26.7 -> v1.55.8
- github.com/coreos/go-semver: v0.3.0 -> v0.3.1
- github.com/cpuguy83/go-md2man/v2: v2.0.2 -> v2.0.7
- github.com/joho/godotenv: v1.3.0 -> v1.5.1
- github.com/jmespath/go-jmespath: v0.0.0 -> v0.4.0
- github.com/sirupsen/logrus: v1.9.0 -> v1.9.4
- github.com/urfave/cli: v1.22.2 -> v1.22.17
- golang.org/x/sys: v0.30.0 -> v0.42.0

Fixes: CI-21699