### PR TITLE
fix: [CI-21699]: Fix EOL Go stdlib vulnerability in drone-buildx-ecr

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.24.11
+go 1.26
 
-toolchain go1.25.5
+toolchain go1.26.0

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,6 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/drone-plugins/drone-buildx v1.3.15 h1:yC7TPybKsOmkTKZGpnRKoD8x5WGNSoZuIZvf5R+76L4=
-github.com/drone-plugins/drone-buildx v1.3.15/go.mod h1:6eZFsU2bAsY1GAmpw4vQODk/6VIyC+UdbArbALPUHJw=
 github.com/drone-plugins/drone-buildx v1.3.16 h1:SwTLl5s86arm27RIJXYGwV+eFhGzgnE/vveuTdP/6sQ=
 github.com/drone-plugins/drone-buildx v1.3.16/go.mod h1:6eZFsU2bAsY1GAmpw4vQODk/6VIyC+UdbArbALPUHJw=
 github.com/drone-plugins/drone-plugin-lib v0.4.2 h1:EiJ3Kco6ypP5noBQqVt1bBbuO1eUAumtPvLTX/NVAYg=


### PR DESCRIPTION
- Updated Go version from 1.24.11 (EOL: 2026-02-11) to 1.26 (supported)
- Updated toolchain from go1.25.5 to go1.26.0
- Ran go mod tidy to update go.sum accordingly

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

AI-Session-Id: 2ddbb7f6-71bc-4b6c-8cc0-9ca7eac894fc
AI-Tool: claude-code
AI-Model: global.anthropic.claude-sonnet-4-6