### PR TITLE
feat:[CI-23139]: Bumping the buildx version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.10
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.55.3
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.7
-	github.com/drone-plugins/drone-buildx v1.3.15
+	github.com/drone-plugins/drone-buildx v1.3.20
 	github.com/joho/godotenv v1.3.0
 )
 
@@ -33,6 +33,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.24.11
-
-toolchain go1.25.5
+go 1.26

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/drone-plugins/drone-buildx v1.3.15 h1:yC7TPybKsOmkTKZGpnRKoD8x5WGNSoZuIZvf5R+76L4=
-github.com/drone-plugins/drone-buildx v1.3.15/go.mod h1:6eZFsU2bAsY1GAmpw4vQODk/6VIyC+UdbArbALPUHJw=
+github.com/drone-plugins/drone-buildx v1.3.20 h1:Oe9Jn/fyBS7YKRlvSnEGUS5ouN6M+Yhwjf75Acap2sw=
+github.com/drone-plugins/drone-buildx v1.3.20/go.mod h1:MbPN45ES9bvQIO8NP7liagrZy5y+Oz0GLNgp6Se6Kf8=
 github.com/drone-plugins/drone-plugin-lib v0.4.2 h1:EiJ3Kco6ypP5noBQqVt1bBbuO1eUAumtPvLTX/NVAYg=
 github.com/drone-plugins/drone-plugin-lib v0.4.2/go.mod h1:KwCu92jFjHV3xv2hu5Qg/8zBNvGwbhoJDQw/EwnTvoM=
 github.com/drone/drone-go v1.7.1 h1:ZX+3Rs8YHUSUQ5mkuMLmm1zr1ttiiE2YGNxF3AnyDKw=


### PR DESCRIPTION
- Bumping the drone-buildx version to support the DLC with the Azure backend
- Build pipeline: https://app.harness.io/ng/account/gCoPSwHxS7ipOgx2iA9tOQ/module/ci/orgs/default/projects/Drone_Plugins/pipelines/dronebuildxharness/deployments/YQ-HRwTDTRCFjcCGPxE2RQ/pipeline?connectorRef=GitHub_Drone_Plugins_Org&repoName=drone-buildx&storeType=REMOTE&step=tM-9oPlWTm6Wf3D_Jomy8Q&stage=ueslzrD0TU6lmVe3OcIBGg&childStage=&stageExecId=ueslzrD0TU6lmVe3OcIBGg
