### PR TITLE
feat: [CI-23661]: windows 2025 support

### DIFF
--- a/docker/ecr/Dockerfile.windows.amd64.ltsc2025
+++ b/docker/ecr/Dockerfile.windows.amd64.ltsc2025
@@ -1,0 +1,10 @@
+# escape=`
+FROM plugins/buildx:windows-ltsc2025-amd64
+
+LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `
+  org.label-schema.name="Drone ECR" `
+  org.label-schema.vendor="Drone.IO Community" `
+  org.label-schema.schema-version="1.0"
+
+ADD release/windows/amd64/buildx-ecr.exe C:/bin/buildx-ecr.exe
+ENTRYPOINT [ "C:\\bin\\buildx-ecr.exe" ]

--- a/docker/ecr/manifest.tmpl
+++ b/docker/ecr/manifest.tmpl
@@ -29,3 +29,9 @@ manifests:
       architecture: amd64
       os: windows
       version: ltsc2022
+  -
+    image: plugins/buildx-ecr:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}windows-ltsc2025-amd64
+    platform:
+      architecture: amd64
+      os: windows
+      version: ltsc2025


### PR DESCRIPTION
This pull request adds support for Windows Server 2025 (`ltsc2025`) to the Drone ECR plugin. The main changes include adding a new Dockerfile for the `windows-ltsc2025-amd64` platform and updating the manifest to include the new image.

**Windows Server 2025 (ltsc2025) support:**

* Added a new Dockerfile, `docker/ecr/Dockerfile.windows.amd64.ltsc2025`, to build the Drone ECR plugin for the `windows-ltsc2025-amd64` platform.
* Updated `docker/ecr/manifest.tmpl` to include the new `windows-ltsc2025-amd64` image in the multi-platform manifest.