### PR TITLE
feat: [CI-23744]: bump drone-buildx to v1.3.23 for proxy and CA support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.10
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.55.3
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.7
-	github.com/drone-plugins/drone-buildx v1.3.20
+	github.com/drone-plugins/drone-buildx v1.3.23
 	github.com/joho/godotenv v1.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/drone-plugins/drone-buildx v1.3.20 h1:Oe9Jn/fyBS7YKRlvSnEGUS5ouN6M+Yhwjf75Acap2sw=
-github.com/drone-plugins/drone-buildx v1.3.20/go.mod h1:MbPN45ES9bvQIO8NP7liagrZy5y+Oz0GLNgp6Se6Kf8=
+github.com/drone-plugins/drone-buildx v1.3.23 h1:ntXvbatGFU8oIuQU2n6kARn93EfrS2jVKs9MDBvYaDc=
+github.com/drone-plugins/drone-buildx v1.3.23/go.mod h1:MbPN45ES9bvQIO8NP7liagrZy5y+Oz0GLNgp6Se6Kf8=
 github.com/drone-plugins/drone-plugin-lib v0.4.2 h1:EiJ3Kco6ypP5noBQqVt1bBbuO1eUAumtPvLTX/NVAYg=
 github.com/drone-plugins/drone-plugin-lib v0.4.2/go.mod h1:KwCu92jFjHV3xv2hu5Qg/8zBNvGwbhoJDQw/EwnTvoM=
 github.com/drone/drone-go v1.7.1 h1:ZX+3Rs8YHUSUQ5mkuMLmm1zr1ttiiE2YGNxF3AnyDKw=


### PR DESCRIPTION
## Problem

When a CI Build-and-Push step uses the `docker-container` buildx driver behind the Harness egress proxy (TLS-intercepting), base-image pulls fail because:

1. The BuildKit container does not inherit proxy environment variables
2. The BuildKit container does not trust the HARNESS_CA_PATH certificate

This affects customers like HNB (Huntington) running builds behind the Harness egress proxy.

## Root Cause

drone-buildx-ecr depends on drone-buildx v1.3.20, which does not forward standard proxy environment variables (http_proxy, https_proxy, no_proxy) or HARNESS_CA_PATH to the BuildKit docker-container driver.

The BuildKit container runs in an isolated filesystem and does not inherit host environment or files unless explicitly passed via `--driver-opt env.*`

## Solution

Bump drone-buildx dependency from v1.3.20 to v1.3.23 to inherit proxy and CA forwarding capabilities implemented in https://github.com/drone-plugins/drone-buildx/pull/115

## Changes Made

- **go.mod**: Updated `github.com/drone-plugins/drone-buildx` from v1.3.20 → v1.3.23
- **go.sum**: Updated checksums for new dependency version

The v1.3.23 release includes:
- ✅ Standard proxy variable forwarding (http_proxy, https_proxy, no_proxy) with precedence: standard → uppercase → HARNESS_*
- ✅ HARNESS_CA_PATH certificate forwarding to BuildKit container via driver-opt env vars
- ✅ Comma-separated no_proxy value quoting to prevent buildx CSV parser issues

## Testing

- ✅ Local build: `go build ./...` passes
- ✅ Local tests: `go test ./...` passes
- CI checks will validate multi-platform builds

## Related Issues/Logs

- Parent ticket: [CI-23744](https://harness.atlassian.net/browse/CI-23744)
- Core fix: https://github.com/drone-plugins/drone-buildx/pull/115
- Sibling PR (drone-buildx-acr): https://github.com/drone-plugins/drone-buildx-acr/pull/65

---
🚢 *Shipped via [Ship](https://github.com/raghavharness/knowledge-base)*

[CI-23744]: https://harness.atlassian.net/browse/CI-23744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ